### PR TITLE
Inverts timeZoneOffset instead of absolute value

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -27,7 +27,7 @@ const methods = {
 
     return moment(epoch)
       .utc()
-      .add(Math.abs(typeof timeZoneOffset !== 'undefined' ? timeZoneOffset : new Date().getTimezoneOffset()), 'minutes')
+      .add((typeof timeZoneOffset !== 'undefined' ? timeZoneOffset : new Date().getTimezoneOffset()) * (-1), 'minutes')
       .add(value, 'seconds')
       .format('L LTS')
   },


### PR DESCRIPTION
The timezone offset is not correctly calculated for users with a negative UTC offset. While working with the absolute value works for positive UTC offsets, it does not for negative ones.